### PR TITLE
Allow caching for faster env setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: bionic
 addons:
   apt:
     packages:
-    - mysql-server-5.7
-    - mysql-client-core-5.7
-    - mysql-client-5.7
+      - mysql-server-5.7
+      - mysql-client-core-5.7
+      - mysql-client-5.7
 
 git:
   depth: 5
@@ -21,15 +21,18 @@ cache:
   - directories:
       # Cache vendor folder will speed up environment setup
       - vendor
+      - tests/mysql_profile
 
 services:
   - mysql
 
 env:
-  # Here we list the profiles that we want to test, each one will be tested, per version of PHP, in parallel
-  - PROFILE=testing
+# Here we list the profiles that we want to test, each one will be tested, per version of PHP, in parallel
+#- PROFILE=default
 
 before_install:
+  # execute all of the commands which need to be executed
+  # before installing dependencies
   # Remove xdebug to increase speed
   - phpenv config-rm xdebug.ini
   # Set up database
@@ -37,14 +40,24 @@ before_install:
 
 install:
   # Create setup.php
+  - export PROFILE=${PROFILE:-testing}
   - ln -s .travis.setup.php setup.php
-  - composer update --prefer-dist
+  - if test -e vendor/composer.lock ; then echo "Restoring previous composer lock file"; cp vendor/composer.lock composer.lock; fi
+  - composer install --prefer-dist
+  - cp composer.lock vendor
   # Install the testing profile
   - tests/profile_setup.sh "$PROFILE"
 
 before_script:
+# execute all of the commands which need to be executed
+# before running actual tests
+
+script:
+  # execute all of the commands which
+  # should make the build pass or fail
   # Go into the tests directory to run the tests
   - cd tests/
+  - ../vendor/phpunit/phpunit/phpunit
 
 branches:
   only:

--- a/app/helpers/logHelpers.php
+++ b/app/helpers/logHelpers.php
@@ -33,9 +33,8 @@
  /**
    *
    */
-
-	require_once(__CA_APP_DIR__."/lib/Logging/KLogger/KLogger.php");
-
+   require_once(__CA_LIB_DIR__."/Logging/KLogger/KLogger.php");
+   
 	# ---------------------------------------
 	/**
 	 * Return KLogger instance for import log
@@ -57,7 +56,7 @@
 	function caGetImportLogger($options=null) {
 		return caGetLogger($options, 'batch_metadata_import_log_directory');
 	}
-
+	# ---------------------------------------
 	/**
 	 * Return KLogger instance for log
 	 *
@@ -71,12 +70,14 @@
 	 *                       logToTempDirectoryIfLogDirectoryIsNotWritable = Log to system temporary directory if
 	 *                       configured log directory is not writable. [Default is false]
 	 *
+	 * @param string $opt_name Name of app.conf configuration entry to use for log directory. [Default is null - use current working directory]
+	 *
 	 * @return KLogger instance
 	 * @throws ApplicationException
 	 */
-	function caGetLogger($options=null, $ps_opt_name=null) {
+	function caGetLogger($options=null, $opt_name=null) {
 		$config = Configuration::load();
-		if(!trim($log_dir = $orig_log_dir = caGetOption('logDirectory', $options, $config->get($ps_opt_name)))) {
+		if(!trim($log_dir = $orig_log_dir = caGetOption('logDirectory', $options, $config->get($opt_name)))) {
 			$log_dir = '.';
 		}
 		

--- a/app/lib/BaseModel.php
+++ b/app/lib/BaseModel.php
@@ -163,7 +163,7 @@ class BaseModel extends BaseObject {
 	/**
 	 * @access private
 	 */
-	var $_FIELD_VALUES;
+	var $_FIELD_VALUES = [];
 
 	/**
 	 * @access protected

--- a/app/lib/Utils/CLIUtils/ImportExport.php
+++ b/app/lib/Utils/CLIUtils/ImportExport.php
@@ -460,7 +460,6 @@
 			$vb_dryrun = (bool)$po_opts->getOption('dryrun');
 			$vs_format = $po_opts->getOption('format');
 			$vs_log_dir = $po_opts->getOption('log');
-			$vn_log_level = CLIUtils::getLogLevel($po_opts);
 			
 			$env = json_decode($po_opts->getOption('environment'), true);
 
@@ -468,44 +467,13 @@
 				define("__CA_DONT_DO_SEARCH_INDEXING__", true);
 			}
 
-			if (!ca_data_importers::importDataFromSource($vs_data_source, $vs_mapping, array('dryRun' => $vb_dryrun, 'noTransaction' => $vb_direct, 'format' => $vs_format, 'showCLIProgressBar' => true, 'logDirectory' => $vs_log_dir, 'logLevel' => $vn_log_level, 'logToTempDirectoryIfLogDirectoryIsNotWritable' => $vb_use_temp_directory_for_logs_as_fallback, 'addToSet' => $vs_add_to_set, 'environment' => $env))) {
+			if (!ca_data_importers::importDataFromSource($vs_data_source, $vs_mapping, array('dryRun' => $vb_dryrun, 'noTransaction' => $vb_direct, 'format' => $vs_format, 'showCLIProgressBar' => true, 'logDirectory' => $vs_log_dir, 'logLevel' => $po_opts->getOption('log-level'), 'logToTempDirectoryIfLogDirectoryIsNotWritable' => $vb_use_temp_directory_for_logs_as_fallback, 'addToSet' => $vs_add_to_set, 'environment' => $env))) {
 				CLIUtils::addError(_t("Could not import source %1: %2", $vs_data_source, join("; ", ca_data_importers::getErrorList())));
 				return false;
 			} else {
 				CLIUtils::addMessage(_t("Imported data from source %1", $vs_data_source));
 				return true;
 			}
-		}
-		/**
-		* Helper function to get log levels
-		*/
-		private static function getLogLevel($po_opts){
-			$vn_log_level = KLogger::INFO;
-			switch($vs_log_level = $po_opts->getOption('log-level')) {
-				case 'DEBUG':
-					$vn_log_level = KLogger::DEBUG;
-					break;
-				case 'NOTICE':
-					$vn_log_level = KLogger::NOTICE;
-					break;
-				case 'WARN':
-					$vn_log_level = KLogger::WARN;
-					break;
-				case 'ERR':
-					$vn_log_level = KLogger::ERR;
-					break;
-				case 'CRIT':
-					$vn_log_level = KLogger::CRIT;
-					break;
-				case 'ALERT':
-					$vn_log_level = KLogger::ALERT;
-					break;
-				default:
-				case 'INFO':
-					$vn_log_level = KLogger::INFO;
-					break;
-			}
-			return $vn_log_level;
 		}
 		# -------------------------------------------------------
 		/**

--- a/app/models/ca_data_importers.php
+++ b/app/models/ca_data_importers.php
@@ -773,7 +773,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 		
 		$is_new = true;
 		
-		$o_log = caGetImportLogger($pa_options['logDirectory'], $pa_options['logLevel']);
+		$o_log = caGetImportLogger($pa_options);
 		
 		$o_excel = PHPExcel_IOFactory::load($ps_source);
 		$o_sheet = $o_excel->getActiveSheet();
@@ -1302,7 +1302,7 @@ class ca_data_importers extends BundlableLabelableBaseModelWithAttributes {
 			}
 		}
 		
-		$o_log = caGetImportLogger($pa_options['logDirectory'], $pa_options['logLevel']);
+		$o_log = caGetImportLogger($pa_options);
 		
 		$vb_show_cli_progress_bar 	= (isset($pa_options['showCLIProgressBar']) && ($pa_options['showCLIProgressBar'])) ? true : false;
 		

--- a/tests/database_setup.sh
+++ b/tests/database_setup.sh
@@ -1,24 +1,36 @@
 #!/usr/bin/env bash
 
+export BASE_DIR=$(dirname $0)
+
 # Set environment variables.
+export CACHE_DIR=${CACHE_DIR:-mysql_profile}
 export DB_NAME=${DB_NAME:-ca_test}
 export DB_USER=${DB_USER:-ca_test}
 export DB_PASSWORD=${DB_PASSWORD:-password}
 
+# Create cache dir
+echo "Creating cache dir at ${CACHE_DIR}"
+mkdir -p "${CACHE_DIR}"
+
 # Initialise the database instance for the test.
+echo "Drop existing database"
 sudo mysql -uroot -e "DROP DATABASE ${DB_NAME};"
+echo "Create database"
 sudo mysql -uroot -e "create database ${DB_NAME};"
+echo "Grant permissions to database"
 sudo mysql -uroot -e "grant all on ${DB_NAME}.* to '${DB_USER}'@'localhost' identified by '${DB_PASSWORD}';"
 
 # Add custom configuration from file.
-MYCNF_CONFIG="${MYCNF_CONFIG:-$TRAVIS_BUILD_DIR/tests/my.cnf}"
-if test -e "$MYCNF_CONFIG";
-then
-  cat "$MYCNF_CONFIG" | sudo tee -a /etc/mysql/my.cnf;
+echo "Configuring MySQL server"
+MYCNF_CONFIG="${MYCNF_CONFIG:-../$BASE_DIR/tests/my.cnf}"
+if test -e "$MYCNF_CONFIG"; then
+  cat "$MYCNF_CONFIG" | sudo tee -a /etc/mysql/my.cnf
 fi
 
 # Restart service.
+echo "Restarting MySQL server"
 sudo service mysql restart
 
 # Show variables.
+echo "Show updated MySQL server variables"
 sudo mysql -uroot -e 'show variables;'

--- a/tests/profile_setup.sh
+++ b/tests/profile_setup.sh
@@ -1,10 +1,28 @@
 #!/usr/bin/env bash
 
+export BASE_DIR=$(dirname $0)
+
 # Set environment variables
+export CACHE_DIR=${CACHE_DIR:-$BASE_DIR/mysql_profile}
+export DB_NAME=${DB_NAME:-ca_test}
 export PROFILE=${1:-testing}
 export COLLECTIVEACCESS_HOME="$(dirname $(dirname "$0"))"
 export PATH="$PATH:$COLLECTIVEACCESS_HOME/support/bin"
+export PHP_BIN=${PHP_BIN:-php}
 
 # Install the testing profile
-"$COLLECTIVEACCESS_HOME"/support/bin/caUtils install --hostname=localhost --setup="tests/setup-tests.php" \
-  --skip-roles --profile-name="$PROFILE" --admin-email=support@collectiveaccess.org
+if test ! -e "$CACHE_DIR/$PROFILE.sql" -o -n "$SKIP_CACHED_PROFILE"; then
+  echo "Installing profile $PROFILE..."
+  "$PHP_BIN" "$COLLECTIVEACCESS_HOME"/support/bin/caUtils install --hostname=localhost --setup="tests/setup-tests.php" \
+    --skip-roles --profile-name="$PROFILE" --admin-email=support@collectiveaccess.org && (
+        # Export database for later faster import
+        echo "Exporting database to cache file: $CACHE_DIR/$PROFILE.sql"
+        sudo mysqldump -uroot --hex-blob --complete-insert --extended-insert $DB_NAME >"$CACHE_DIR/$PROFILE.sql"
+  )
+else
+  echo "Skipping profile install"
+  if test -e "$CACHE_DIR/$PROFILE.sql" -a -z "$SKIP_CACHED_PROFILE"; then
+    echo "Found cached database file $CACHE_DIR/$PROFILE.sql. Importing..."
+    sudo mysql -uroot "$DB_NAME" <"$CACHE_DIR/$PROFILE.sql"
+  fi
+fi


### PR DESCRIPTION
Allow caching `composer` and database for faster env setup, test time reduction of about 30-50%, with same reliability.

It uses Travis-CI caching facility for caching:
- `vendor` folder. It will copy `composer.lock` file to `vendor` folder too, so restoring the configuration is extremely fast.
- profile database dump. It will dump database after profile installation. It will load it again on the next execution. It will speed database creation (creating relationships and other tables are really slow). If you would like to skip profile database caching, set env variable `SKIP_CACHED_PROFILE` to any non-empty value.
