### PR TITLE
BUG Media viewer does not use image tile size.

### DIFF
--- a/app/helpers/htmlFormHelpers.php
+++ b/app/helpers/htmlFormHelpers.php
@@ -410,9 +410,13 @@
 			$vn_width = 						(int)$pa_options["width"];
 			$vn_height = 						(int)$pa_options["height"];
 			
-			$vn_tile_width = 					(int)$pa_options["tile_width"];
-			$vn_tile_height = 					(int)$pa_options["tile_height"];
-			
+			$vn_tile_width = 					caGetOption('tile_width', $pa_options, 256, array('castTo'=>'int'));
+			$vn_tile_height = 					caGetOption('tile_height', $pa_options, 256, array('castTo'=>'int'));
+			// Tiles must be square.
+			if ($vn_tile_width != $vn_tile_height){
+				$vn_tile_height = $vn_tile_width;
+			}
+
 			$vn_layers = 						(int)$pa_options["layers"];
 			
 			if (!($vs_id_name = (string)$pa_options["idname"])) {
@@ -465,7 +469,8 @@
 			$va_opts['info'] = array(
 				'width' => $vn_width,
 				'height' => $vn_height,
-				'tilesize'=> 256,
+				// Set tile size using function options.
+				'tilesize'=> $vn_tile_width,
 				'levels' => $vn_layers
 			);
 			

--- a/tests/helpers/HtmlFormHelpersTest.php
+++ b/tests/helpers/HtmlFormHelpersTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) Orestes Sanchez Benavente <orestes@estotienearreglo.es> 2020
+ */
+use PHPUnit\Framework\TestCase;
+ 
+require_once(__CA_APP_DIR__."/helpers/displayHelpers.php");
+
+class HtmlFormHelpersTest extends TestCase {
+	# -------------------------------------------------------
+	public function testImageUsesDefaultTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+		));
+		$this->assertStringContainsString('"tilesize":256', $result);
+	}
+	# -------------------------------------------------------
+	public function testImageUsesCustomTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+			'tile_width' => 512
+		));
+		$this->assertStringContainsString('"tilesize":512', $result);
+	}
+	# -------------------------------------------------------
+	public function testImageDoesNotUseHeightTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+			'tile_height' => 1024
+		));
+		// Uses default tilesize
+		$this->assertStringContainsString('"tilesize":256', $result);
+	}
+	# -------------------------------------------------------
+	public function testImagePrefersWidthTileSize() {
+		$result = caHTMLImage('http://example.com/image.tpc', array(
+			'tile_width' => 1024,
+			'tile_height' => 512
+		));
+		// Uses default tilesize
+		$this->assertStringContainsString('"tilesize":1024', $result);
+	}
+	# -------------------------------------------------------
+	public function testJpegImageDoesNotUseTiles() {
+		$result = caHTMLImage('http://example.com/image.jpg', array());
+		$this->assertStringNotContainsString('"tilesize"', $result);
+	}
+	# -------------------------------------------------------
+	# -------------------------------------------------------
+}


### PR DESCRIPTION
I configured media_processing rules to allow a tile size of 512px and then images are shown with disordered tiles.

I traced the error to the way the tile viewer is configured in `htmlFormHelpers.php`, and there is a hardcoded value of `256`.

I also added some tests.